### PR TITLE
Check fetch response status and scanner errors

### DIFF
--- a/job/run.go
+++ b/job/run.go
@@ -72,14 +72,20 @@ func fetch(url string) ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
-	scanner := bufio.NewScanner(resp.Body)
 	defer func() {
 		if err = resp.Body.Close(); err != nil {
 			logger("defer fetch", "close body error: %s", err)
 		}
 	}()
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		return nil, fmt.Errorf("unexpected status code %d for url %s", resp.StatusCode, url)
+	}
+	scanner := bufio.NewScanner(resp.Body)
 	for scanner.Scan() {
 		rows = append(rows, scanner.Text())
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, err
 	}
 
 	return rows, nil


### PR DESCRIPTION
### Motivation
- Ensure `fetch` fails fast when the HTTP response is not a successful 2xx status to avoid treating error pages as valid data.
- Surface any scanning errors that occurred while reading the response body instead of hiding them.
- Preserve the existing deferred `resp.Body.Close()` behavior so the response body is always cleaned up.

### Description
- Added an HTTP status check in `fetch` that returns `fmt.Errorf("unexpected status code %d for url %s", resp.StatusCode, url)` for non-2xx responses.
- Moved `bufio.NewScanner(resp.Body)` below the status check and kept the deferred `resp.Body.Close()` intact.
- Added a post-read check for `scanner.Err()` and return the error if present.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695b246464c88321ae78146f28643300)