### PR TITLE
Default stream domain comment to ikuai-aio

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -188,6 +188,9 @@ func (c *Config) matchCronStreamDomain() {
 		if len(slice) > 4 {
 			comment = slice[4]
 		}
+		if len(comment) == 0 {
+			comment = "ikuai-aio"
+		}
 
 		if _, exist := m[id]; !exist {
 			m[id] = &IKuaiCronStreamDomain{


### PR DESCRIPTION
### Motivation

- Ensure stream domain cron entries receive a default comment when none is provided to match Custom ISP behavior.
- Avoid mismatches in `updateStreamDomain` which identifies existing entries by `Comment` when cleaning and re-adding rules.
- Make config parsing behavior consistent and reduce the need for explicit `comment` values in `deploy/docker-compose.yml`.

### Description

- Add a fallback in `matchCronStreamDomain()` to set `comment` to "ikuai-aio" when the parsed comment is empty.
- Change applied in `config/config.go` inside the `matchCronStreamDomain()` function.
- This aligns stream domain defaulting with the existing `CustomISP` path which defaults comment to `ikuai-aio` in `api.CustomISPAdd`.

### Testing

- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695b2466fe5c8321be31712897c43127)